### PR TITLE
Match omitting `eslint-plugin` in rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Then configure the rules you want to use under the rules section.
 ```json
 {
     "rules": {
-        "eslint-no-global-lodash/no-global-lodash": 2
+        "no-global-lodash/no-global-lodash": 2
     }
 }
 ```


### PR DESCRIPTION
If you do not use the full module name, you must match this name to the prefix on the rule.